### PR TITLE
Add #3; Optimize program on_prev or on_next

### DIFF
--- a/visual_comparison/config.ini
+++ b/visual_comparison/config.ini
@@ -4,6 +4,7 @@ theme = dark-blue
 
 [Display]
 interpolation_type = cv2.INTER_NEAREST
+fast_loading_threshold_ms = 100
 
 [Zoom]
 interpolation_type = cv2.INTER_NEAREST

--- a/visual_comparison/configurations.py
+++ b/visual_comparison/configurations.py
@@ -28,6 +28,7 @@ config_info = dict(
     ),
     Display=dict(
         interpolation_type=dict(obj="options", type=eval, values=CV2_INTERPOLATION_TYPES, default="cv2.INTER_LINEAR"),
+        fast_loading_threshold_ms=dict(obj="entry", type=int, default=100),
     ),
     Zoom=dict(
         interpolation_type=dict(obj="options", type=eval, values=CV2_INTERPOLATION_TYPES, default="cv2.INTER_NEAREST"),

--- a/visual_comparison/managers/__init__.py
+++ b/visual_comparison/managers/__init__.py
@@ -1,3 +1,4 @@
 from .content_manager import *
+from .fast_load_checker import *
 from .video_writer import *
 from .zoom_manager import *

--- a/visual_comparison/managers/fast_load_checker.py
+++ b/visual_comparison/managers/fast_load_checker.py
@@ -1,0 +1,26 @@
+import time
+
+
+__all__ = ["FastLoadChecker"]
+
+
+class FastLoadChecker:
+    def __init__(self):
+        self.prev_called_time = 0
+        self.curr_called_time = 1000
+
+    def update(self):
+        """
+        Call this when button is pressed
+        """
+        self.prev_called_time = self.curr_called_time
+        self.curr_called_time = time.time()
+
+    def check(self, threshold_ms) -> bool:
+        """
+        Checks if it requires fast loading
+        :return:
+        """
+        time_between_calls_ms = (self.curr_called_time - self.prev_called_time) * 1000
+        time_since_last_press = (time.time() - self.curr_called_time) * 1000
+        return time_between_calls_ms < threshold_ms and time_since_last_press < threshold_ms

--- a/visual_comparison/visual_comparison_app.py
+++ b/visual_comparison/visual_comparison_app.py
@@ -528,8 +528,7 @@ class VisualComparisonApp(customtkinter.CTk):
 
         # Fast loading - Activates if change file button is held repeatedly (a, d, <, > keys)
         # Prevents very long load times when has many videos/images to load and want to use buttons to switch quickly
-        # TODO: Put in config, Check if works on video
-        if self.fast_load_checker.check(threshold_ms=100) and self.app_status.STATE == VCState.UPDATE_FILE:
+        if self.fast_load_checker.check(threshold_ms=self.configurations["Display"]["fast_loading_threshold_ms"]) and self.app_status.STATE == VCState.UPDATE_FILE:
             cap = file_reader.read_media_file(self.content_handler.get_paths()[0])
             ret, display_image = cap.read()
             self.display_handler.update_image(display_image, self.configurations["Display"]["interpolation_type"])


### PR DESCRIPTION
When switching files quickly using "a" or "d", we do not need to load all the files.

Solution here is to have a class to check when the last 2 button presses were called. If difference is lesser than the threshold, we want to load 1 file only for preview instead of loading all the files which could be slow.